### PR TITLE
Add support for Centos 7.7 builds

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ common:
  result_dir: 'result'
  verbose: False
  log_size: 2097152
- packages_metadata_repo_url: "https://github.com/NXPower/versions.git"
+ packages_metadata_repo_url: "/home/nutanix/devel/versions"
  packages_metadata_repo_branch: '2.0-nutanix'
  nutanix_version_base_commit: '2.0-2017-03-31'
  nutanix_version: '20170331.${num_commits}'
@@ -63,13 +63,18 @@ build_iso:
         - "debugging"
         - "nutanix-ahv-group"
     iso_root_fs_packages:
+        - "anaconda"
+        - "anaconda-dracut"
+        # packages needed by anaconda
+        - "redhat-upgrade-dracut"
         - "grub2"
+        - "yum-langpacks"
     mock_iso_repo_name: "host_os"
     mock_iso_repo_dir: "/host-os-repo"
     distro_repos_urls:
-        base: "http://vault.centos.org/altarch/7.3.1611/os/ppc64le/"
-        updates: "http://vault.centos.org/altarch/7.3.1611/updates/ppc64le/"
-        extras: "http://vault.centos.org/altarch/7.3.1611/extras/ppc64le/"
+        base: "http://vault.centos.org/altarch/7.7.1908/os/ppc64le/"
+        updates: "http://vault.centos.org/altarch/7.7.1908/updates/ppc64le/"
+        extras: "http://vault.centos.org/altarch/7.7.1908/extras/ppc64le/"
         epel: "http://download.fedoraproject.org/pub/epel/7/ppc64le/"
     distro_repo_args:
         - "--excludepkgs=kernel*,qemu*,libvirt,libvirt-client,libvirt-daemon*,SLOF,nmap-ncat"

--- a/config.yaml
+++ b/config.yaml
@@ -77,7 +77,7 @@ build_iso:
         extras: "http://vault.centos.org/altarch/7.7.1908/extras/ppc64le/"
         epel: "http://download.fedoraproject.org/pub/epel/7/ppc64le/"
     distro_repo_args:
-        - "--excludepkgs=kernel*,qemu*,libvirt,libvirt-client,libvirt-daemon*,SLOF,nmap-ncat"
+        - "--excludepkgs=kernel*,qemu*,libvirt,libvirt-client,libvirt-daemon*,nmap-ncat"
 update_metapackage:
  push_repo_url:
  push_repo_branch: "master"

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ common:
  result_dir: 'result'
  verbose: False
  log_size: 2097152
- packages_metadata_repo_url: "/home/nutanix/devel/versions"
+ packages_metadata_repo_url: "https://github.com/NXPower/versions.git"
  packages_metadata_repo_branch: '2.0-nutanix'
  nutanix_version_base_commit: '2.0-2017-03-31'
  nutanix_version: '20170331.${num_commits}'

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -162,10 +162,11 @@ class MockPungiIsoBuilder(object):
 	
 	# Increase the size of the temporary loop device used to build the live rootfs image
         self._run_mock_command(
-                "--shell 'sed -i s?size=2\):?size=4\):? /usr/lib/python2.7/site-packages/pylorax/treebuilder.py'");
+                "--shell 'sed -i s?size=2,?size=4,? /usr/lib/python2.7/site-packages/pylorax/__init__.py'");
 	
-        # TODO: This almost works, but the remembered word pattern \1\2 resolves to ^A^B instead of the matched pattern
-        #'--shell "sed -i -r \'s/(def[ \t]+create_runtime\()+(.*)+size=2\):/\1\2size=4\):/\' /usr/lib/python2.7/site-packages/pylorax/treebuilder.py"');
+	# Increase the size of the temporary loop device used to build the live rootfs image
+        self._run_mock_command(
+                "--shell 'sed -i s?size=2\):?size=4\):? /usr/lib/python2.7/site-packages/pylorax/treebuilder.py'");
 
         build_cmd = ("pungi -c %s --nosource --nodebuginfo --name %s --ver %s -B -I" %
                     (self.config.get('automated_install_file'),

--- a/lib/iso_builder.py
+++ b/lib/iso_builder.py
@@ -159,6 +159,13 @@ class MockPungiIsoBuilder(object):
 	# it fails.  Interestingly, dracut only produces one warning anyway.
         self._run_mock_command(
 		"--shell 'sed -i s?proc/modules?proc-modules? /usr/lib/python2.7/site-packages/pylorax/treebuilder.py'");
+	
+	# Increase the size of the temporary loop device used to build the live rootfs image
+        self._run_mock_command(
+                "--shell 'sed -i s?size=2\):?size=4\):? /usr/lib/python2.7/site-packages/pylorax/treebuilder.py'");
+	
+        # TODO: This almost works, but the remembered word pattern \1\2 resolves to ^A^B instead of the matched pattern
+        #'--shell "sed -i -r \'s/(def[ \t]+create_runtime\()+(.*)+size=2\):/\1\2size=4\):/\' /usr/lib/python2.7/site-packages/pylorax/treebuilder.py"');
 
         build_cmd = ("pungi -c %s --nosource --nodebuginfo --name %s --ver %s -B -I" %
                     (self.config.get('automated_install_file'),

--- a/mock_configs/CentOS/7/CentOS-7-ppc64le.cfg
+++ b/mock_configs/CentOS/7/CentOS-7-ppc64le.cfg
@@ -19,6 +19,7 @@ config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
 
 config_opts['yum.conf'] = """
 [main]
@@ -37,7 +38,7 @@ mdpolicy=group:primary
 # repos
 [base]
 name=BaseOS
-baseurl=http://vault.centos.org/altarch/7.3.1611/os/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/os/ppc64le/
 failovermethod=priority
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7,file:///etc/pki/mock/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=0
@@ -45,7 +46,7 @@ gpgcheck=0
 [updates]
 name=updates
 enabled=1
-baseurl=http://vault.centos.org/altarch/7.3.1611/updates/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/updates/ppc64le/
 failovermethod=priority
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7,file:///etc/pki/mock/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=0
@@ -59,7 +60,7 @@ gpgcheck=0
 
 [extras]
 name=extras
-baseurl=http://vault.centos.org/altarch/7.3.1611/extras/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/extras/ppc64le/
 failovermethod=priority
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7,file:///etc/pki/mock/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=0

--- a/mock_configs/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
+++ b/mock_configs/CentOS/7/build-iso-CentOS-7-ppc64le.cfg
@@ -15,11 +15,13 @@ config_opts["macros"]["%__gzip"] = "/usr/bin/pigz"
 config_opts["macros"]["%__bzip2"] = "/usr/bin/lbzip2"
 config_opts['nspawn_args'] = ["--bind=/dev", "--bind=/dev/pts", "--bind=/dev/shm"]
 config_opts['nspawn_args'] += ["--share-system"]
+config_opts['nspawn_args'] += ["--capability=all"]
 config_opts['root'] = 'CentOS-7-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['package_manager'] = 'yum'
 
 config_opts['yum.conf'] = """
 [main]
@@ -34,11 +36,12 @@ assumeyes=1
 syslog_ident=mock
 syslog_device=
 mdpolicy=group:primary
+http_caching=packages
 
 # repos
 [base]
 name=BaseOS
-baseurl=http://vault.centos.org/altarch/7.3.1611/os/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/os/ppc64le/
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos//RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1
@@ -46,7 +49,7 @@ gpgcheck=1
 [updates]
 name=updates
 enabled=1
-baseurl=http://vault.centos.org/altarch/7.3.1611/updates/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/updates/ppc64le/
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1
@@ -60,7 +63,7 @@ gpgcheck=1
 
 [extras]
 name=extras
-baseurl=http://vault.centos.org/altarch/7.3.1611/extras/ppc64le/
+baseurl=http://vault.centos.org/altarch/7.7.1908/extras/ppc64le/
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1


### PR DESCRIPTION
Centos 7.3 used to be supported, but no longer works with EPEL 7, so the
build process is being updated to support Centos 7.7 to resolve the EPEL
7 problem.  Several changes to the build process have been made, including:

- updating the minimal repository package list to explicitly include
  anaconda, anaconda-dracut, grub2, etc.  These changes are ported from
  the upstream parent project open-power-host-os.

- updating the yum repos to point at Centos 7.3.1611 Altarch

- pylorax crash workaround of an extraneous reference to installroot/proc/modules

- use old distro install tools (yum) instead of new tool (dnf).

- minimize upstream yum caching as it seems to fail less often when downloading epel

Signed-off-by: Luke Browning [IBM] <918375@nutanix.com>